### PR TITLE
DB関連のベース

### DIFF
--- a/src/db/db.js
+++ b/src/db/db.js
@@ -1,0 +1,8 @@
+import KeyFactory from "/db/utils/key_factory.js";
+
+const kv = await Deno.openKv();
+
+// sample
+export async function getTicket(ticketId) {
+  return (await kv.get(KeyFactory.ticketKey(ticketId))).value;
+}

--- a/src/db/utils/key_factory.js
+++ b/src/db/utils/key_factory.js
@@ -1,0 +1,6 @@
+export default class KeyFactory {
+  // sample
+  static ticketKey(ticketId) {
+    return ["tickets", ticketId];
+  }
+}


### PR DESCRIPTION
KV を使うコードは src/db/db.js に書きたい。

KVのキーに関する知識は KeyFactory に集約して、db.js 内ではキーの具体的な定義を意識せずに使えるようにしたい。