### PR TITLE
🚑 ユーザー登録機能がDeno Deploy上で動作しない不具合の修正

### DIFF
--- a/src/controllers/user_controller.js
+++ b/src/controllers/user_controller.js
@@ -1,7 +1,7 @@
 import * as Errors from "/utils/errors.js";
 import { kv } from "/db/kv.js";
 import KeyFactory from "/db/key_factory.js";
-import * as bcrypt from "bcrypt/mod.ts";
+import HashHelper from "/utils/hash_helper.js";
 
 export default class UserController {
   static async create({ request, cookies, response }) {
@@ -31,7 +31,7 @@ export default class UserController {
     }
 
     // createUser
-    const passwordHash = await bcrypt.hash(password);
+    const passwordHash = await HashHelper.hash(password);
     const newUser = { username, passwordHash };
     await kv.set(KeyFactory.userKey(username), newUser);
 

--- a/src/utils/hash_helper.js
+++ b/src/utils/hash_helper.js
@@ -1,0 +1,16 @@
+import { compareSync, hashSync } from "bcrypt/mod.ts";
+
+/**
+ * Deno Deploy で bcrypt の hash, compare が使えない。
+ * hashSync, compareSync は使えるので非同期にして使う。
+ * see: https://github.com/JamesBroadberry/deno-bcrypt/issues/26
+ */
+export default class HashHelper {
+  static hash(plaintext) {
+    return new Promise((res) => res(hashSync(plaintext)));
+  }
+
+  static compare(plaintext, hash) {
+    return new Promise((res) => res(compareSync(plaintext, hash)));
+  }
+}


### PR DESCRIPTION
bcrypt が Deno Deploy 上で動作しなかった。

hash, compare は動かないが hashSync, compareSync は動くようなので https://github.com/JamesBroadberry/deno-bcrypt/issues/26 を参考にして修正した