### PR TITLE
✨ サインイン機能

### DIFF
--- a/src/controllers/auth_controller.js
+++ b/src/controllers/auth_controller.js
@@ -1,0 +1,40 @@
+import * as Errors from "/utils/errors.js";
+import { kv } from "/db/kv.js";
+import KeyFactory from "/db/key_factory.js";
+import HashHelper from "/utils/hash_helper.js";
+
+export default class AuthController {
+  static async signin({ request, cookies, response }) {
+    const json = await request.body.json();
+    const { username, password } = json;
+
+    if (
+      typeof username !== "string" ||
+      username === "" ||
+      typeof password !== "string" ||
+      password === ""
+    ) {
+      response.body = Errors.BAD_REQUEST;
+      return;
+    }
+
+    const user = (await kv.get(KeyFactory.userKey(username))).value;
+    if (!user) {
+      response.body = Errors.WRONG_USERNAME_OR_PASSWORD;
+      return;
+    }
+
+    const isCorrectPassword = await HashHelper.compare(
+      password,
+      user.passwordHash,
+    );
+    if (!isCorrectPassword) {
+      response.body = Errors.WRONG_USERNAME_OR_PASSWORD;
+      return;
+    }
+
+    cookies.set("username", username);
+
+    response.body = { username };
+  }
+}

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,6 @@
 import { Router } from "@oak/oak";
 import * as Errors from "/utils/errors.js";
+import AuthController from "/controllers/auth_controller.js";
 import UserController from "/controllers/user_controller.js";
 import QuestionController from "/controllers/question_controller.js";
 
@@ -15,7 +16,7 @@ router.get("/error/400", (ctx) => {
 });
 
 router.post("/signup", UserController.create);
-router.post("/signin", () => {});
+router.post("/signin", AuthController.signin);
 router.post("/signout", () => {});
 
 router.post("/questions", QuestionController.postQuestion);

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -16,6 +16,10 @@ export const UNKNOWN_INVITE_CODE = error(
   1002,
   "不明な招待コード",
 );
+export const WRONG_USERNAME_OR_PASSWORD = error(
+  1003,
+  "ユーザー名またはパスワードが誤っています",
+);
 
 function error(code, message) {
   return { error: { code, message } };


### PR DESCRIPTION
サインイン機能を実装しました！

# 仕様

ユーザー名とパスワードの組が正しければ Cookie を付与する

`POST /signin`

| フィールド | 要件 |
| -- | -- |
| username | 空でない文字列 |
| password | 空でない文字列 |

# テスト

前提：

- 次のユーザーを作成した
```
POST /signup
>> {
    "username": "john-doe-035",
    "password": "pass1234",
    "inviteCode": "foobar"
}
```

テストケース：ユーザー名とパスワードの組が正しければ成功する
```
POST /signin
>> {
    "username": "john-doe-035",
    "password": "pass1234"
}
<< {
    "username": "john-doe-035"
}
```
このとき、Cookie に username=john-doe-035 が設定される

テストケース：パスワードが誤っていれば失敗する
```
>> {
    "username": "john-doe-035",
    "password": "wrongpassword"
}
<< {
    "error": {
        "code": 1003,
        "message": "ユーザー名またはパスワードが誤っています"
    }
}
```